### PR TITLE
Refactor call logic and add interceptors to rpc client

### DIFF
--- a/bech_test.go
+++ b/bech_test.go
@@ -14,7 +14,7 @@ type TestEchoRequest struct {
 	Value string `json:"value"`
 }
 
-func BenchmarkPrimeNumbers(b *testing.B) {
+func BenchmarkEchoServ(b *testing.B) {
 	redisClient := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})

--- a/client.go
+++ b/client.go
@@ -81,7 +81,7 @@ func (c *Client) Call(ctx context.Context, method string, params any) (*Response
 	// Ensure that the handleResponses function is only called once
 	c.once.Do(c.handleResponses)
 
-	return c.call(req)
+	return c.handler(req)
 }
 
 func useInterceptors(handler RequestHandler, interceptors []Interceptor) RequestHandler {

--- a/client_test.go
+++ b/client_test.go
@@ -204,3 +204,25 @@ func TestProcessMessage_NoRequest(_ *testing.T) {
 
 	client.processMessage(msg)
 }
+func TestWithInterceptors(t *testing.T) {
+	interceptor1 := func(handler RequestHandler) RequestHandler {
+		return func(req *Request) (*Response, error) {
+			// Interceptor 1 logic
+			return handler(req)
+		}
+	}
+
+	interceptor2 := func(handler RequestHandler) RequestHandler {
+		return func(req *Request) (*Response, error) {
+			// Interceptor 2 logic
+			return handler(req)
+		}
+	}
+
+	client := NewClient(nil, "test-channel", WithInterceptors(interceptor1, interceptor2))
+
+	// Assert that the interceptors are correctly added to the client
+	if len(client.interceptors) != 2 {
+		t.Errorf("Expected 2 interceptors, but got %d", len(client.interceptors))
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,9 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -224,5 +226,79 @@ func TestWithInterceptors(t *testing.T) {
 	// Assert that the interceptors are correctly added to the client
 	if len(client.interceptors) != 2 {
 		t.Errorf("Expected 2 interceptors, but got %d", len(client.interceptors))
+	}
+}
+
+func TestPrepareRequest(t *testing.T) {
+	c := NewClient(nil, "test-channel")
+
+	ctx := context.Background()
+	method := "test-method"
+	params := struct {
+		Name string
+		Age  int
+	}{
+		Name: "John",
+		Age:  30,
+	}
+
+	req, err := c.prepareRequest(ctx, method, params)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if req.ID == "" {
+		t.Errorf("Expected request ID to be non-empty")
+	}
+
+	if req.Method != method {
+		t.Errorf("Expected request Method to be '%s', but got '%s'", method, req.Method)
+	}
+
+	expectedParams, _ := json.Marshal(params)
+	if !bytes.Equal(req.params, expectedParams) {
+		t.Errorf("Expected request params to be '%s', but got '%s'", expectedParams, req.params)
+	}
+
+	if req.ReplyTo != c.id {
+		t.Errorf("Expected request ReplyTo to be '%s', but got '%s'", c.id, req.ReplyTo)
+	}
+
+	if req.ctx != ctx {
+		t.Errorf("Expected request ctx to be the same as the provided context")
+	}
+}
+
+func TestPrepareRequest_EmptyMethod(t *testing.T) {
+	c := NewClient(nil, "test-channel")
+
+	ctx := context.Background()
+	params := struct {
+		Name string
+		Age  int
+	}{
+		Name: "John",
+		Age:  30,
+	}
+
+	_, err := c.prepareRequest(ctx, "", params)
+
+	if err == nil {
+		t.Errorf("Expected error due to empty method")
+	}
+}
+
+func TestPrepareRequest_MarshalError(t *testing.T) {
+	c := NewClient(nil, "test-channel")
+
+	ctx := context.Background()
+	method := "test-method"
+	params := make(chan int) // Invalid type for JSON marshaling
+
+	_, err := c.prepareRequest(ctx, method, params)
+
+	if err == nil {
+		t.Errorf("Expected error due to JSON marshaling error")
 	}
 }

--- a/interceptors.go
+++ b/interceptors.go
@@ -1,0 +1,7 @@
+package rpc
+
+// ClientInterceptor is a function type that represents an interceptor for client requests.
+// It takes a pointer to a Request struct and returns a pointer to a Response struct and an error.
+type ClientInterceptor func(req *Request) (*Response, error)
+
+type ServerInterceptor func(req *Request) (*Response, error)

--- a/interceptors.go
+++ b/interceptors.go
@@ -2,6 +2,7 @@ package rpc
 
 // ClientInterceptor is a function type that represents an interceptor for client requests.
 // It takes a pointer to a Request struct and returns a pointer to a Response struct and an error.
-type ClientInterceptor func(req *Request) (*Response, error)
 
-type ServerInterceptor func(req *Request) (*Response, error)
+type RequestHandler func(req *Request) (*Response, error)
+
+type Interceptor func(next RequestHandler) RequestHandler


### PR DESCRIPTION
This pull request refactors the call logic into a private method and adds support for interceptors in the RPC client. The `NewClient` function now accepts a variadic `ClientOption` parameter, allowing the user to add interceptors to the client. The `useInterceptors` function is introduced to apply the interceptors to the request handler. The `prepareRequest` function is added to prepare a request to be sent to the RPC server. Additionally, a new file `interceptor.go` is added to define the types for client interceptors.