### PR TITLE
Adds batch reading from the stream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,16 @@ lint:
 	golangci-lint run
 
 profile:
-	go test -benchmem -run=^$$ -bench ^BenchmarkEchoServ$$ -cpuprofile=cpu.out -memprofile=mem.out .
+	go test -benchmem -run=^$$ -benchtime=5s  -bench ^BenchmarkEchoServ$$ -cpuprofile=cpu.out -memprofile=mem.out  -blockprofile=lock.out .
+
+bench:
+	go test -benchmem -run=^$$ -benchtime=5s  -bench ^BenchmarkEchoServ$$ .
 
 analyze_cpu:
 	go tool pprof -http=:8080 rpc-redis.test cpu.out
 
 analyze_mem:
 	go tool pprof -http=:8080 rpc-redis.test mem.out
+
+analyze_block:
+	go tool pprof -http=:8080 rpc-redis.test lock.out

--- a/bech_test.go
+++ b/bech_test.go
@@ -52,7 +52,7 @@ func BenchmarkEchoServ(b *testing.B) {
 	defer rpcServer.Close()
 
 	ctx := context.Background()
-	sem := make(chan struct{}, 3)
+	sem := make(chan struct{}, DefaultConcurency)
 	wg := sync.WaitGroup{}
 
 	b.ResetTimer()

--- a/server.go
+++ b/server.go
@@ -16,7 +16,7 @@ import (
 const (
 	DefaultBatchSize     = 1
 	DefaultBlockInterval = 10 * time.Second
-	DefaultConcurency    = 50
+	DefaultConcurency    = 25
 )
 
 type Handler func(req *Request) (any, error)
@@ -31,11 +31,11 @@ type Server struct {
 	cancel       context.CancelFunc
 	sem          chan struct{}
 	wg           *sync.WaitGroup
+	onGoing      *atomic.Int64
 	stream       string
 	group        string
 	consumer     string
 	interceptors []Interceptor
-	onGoing      *atomic.Int64
 }
 
 // ServerOption is a function type that can be used to configure a Server.

--- a/server.go
+++ b/server.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	DefaultBatchSize     = 1
 	DefaultBlockInterval = 10 * time.Second
 	DefaultConcurency    = 25
 )

--- a/server_test.go
+++ b/server_test.go
@@ -142,7 +142,7 @@ func TestServer_Run(t *testing.T) {
 		Consumer: consumer,
 		Streams:  []string{stream, ">"},
 		Block:    DefaultBlockInterval,
-		Count:    DefaultBatchSize,
+		Count:    DefaultConcurency,
 		NoAck:    false,
 	}
 
@@ -249,7 +249,7 @@ func TestServer_Close(t *testing.T) {
 		Consumer: consumer,
 		Streams:  []string{stream, ">"},
 		Block:    DefaultBlockInterval,
-		Count:    DefaultBatchSize,
+		Count:    DefaultConcurency,
 		NoAck:    false,
 	}
 


### PR DESCRIPTION
This pull request adds a blocking profiler and batch reading functionality to the stream. The blocking profiler allows for better performance analysis by providing CPU profiling information. The batch reading feature improves efficiency by reading multiple messages from the stream at once. These changes enhance the overall performance and scalability of the codebase.